### PR TITLE
Add Core Test Coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,72 @@
+/**
+ * Jest Configuration for Agent Planner
+ */
+module.exports = {
+  // Test environment
+  testEnvironment: 'node',
+
+  // File patterns for tests
+  testMatch: [
+    '**/__tests__/**/*.js',
+    '**/*.test.js',
+    '**/*.spec.js'
+  ],
+
+  // Coverage configuration
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/index.js',
+    '!src/config/**',
+    '!src/db/**',
+    '!src/**/*.test.js',
+    '!src/**/*.spec.js'
+  ],
+
+  // Coverage thresholds (starting low, increase as coverage improves)
+  // Note: Starting with low thresholds to establish baseline
+  // These should be increased as more tests are added
+  coverageThreshold: {
+    global: {
+      branches: 5,
+      functions: 5,
+      lines: 5,
+      statements: 5
+    }
+  },
+
+  // Coverage output
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+
+  // Setup files
+  setupFilesAfterEnv: ['<rootDir>/tests/setup/jest.setup.js'],
+
+  // Module paths
+  modulePathIgnorePatterns: ['<rootDir>/node_modules/'],
+
+  // Test timeout (30 seconds for integration tests)
+  testTimeout: 30000,
+
+  // Verbose output
+  verbose: true,
+
+  // Clear mocks between tests
+  clearMocks: true,
+
+  // Restore mocks after each test
+  restoreMocks: true,
+
+  // Projects for different test types
+  projects: [
+    {
+      displayName: 'unit',
+      testMatch: ['<rootDir>/tests/unit/**/*.test.js', '<rootDir>/src/**/*.test.js'],
+      testEnvironment: 'node'
+    },
+    {
+      displayName: 'integration',
+      testMatch: ['<rootDir>/tests/integration/**/*.test.js'],
+      testEnvironment: 'node'
+    }
+  ]
+};

--- a/src/config/__mocks__/supabase.js
+++ b/src/config/__mocks__/supabase.js
@@ -1,0 +1,80 @@
+/**
+ * Mock Supabase Client for Unit Tests
+ * This mock is automatically used by Jest when jest.mock('../../../src/config/supabase') is called
+ */
+
+// Create a mock query builder factory
+const createMockQueryBuilder = () => {
+  const builder = {
+    select: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+    ilike: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    range: jest.fn().mockReturnThis(),
+    match: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    then: function(resolve) {
+      return Promise.resolve({ data: null, error: null, count: 0 }).then(resolve);
+    }
+  };
+  return builder;
+};
+
+// Create mock Supabase client
+const supabaseAdmin = {
+  from: jest.fn(() => createMockQueryBuilder()),
+  rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
+  auth: {
+    getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    signInWithPassword: jest.fn().mockResolvedValue({ data: { user: null, session: null }, error: null }),
+    signOut: jest.fn().mockResolvedValue({ error: null }),
+    admin: {
+      getUserById: jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    }
+  },
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: { path: 'mock/path' }, error: null }),
+      download: jest.fn().mockResolvedValue({ data: new Blob(), error: null }),
+      remove: jest.fn().mockResolvedValue({ data: null, error: null }),
+      getPublicUrl: jest.fn((path) => ({ data: { publicUrl: `https://mock.supabase.co/bucket/${path}` } }))
+    }))
+  }
+};
+
+// Client-side supabase (same interface for simplicity)
+const supabase = {
+  from: jest.fn(() => createMockQueryBuilder()),
+  rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
+  auth: {
+    getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    setSession: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    signInWithPassword: jest.fn().mockResolvedValue({ data: { user: null, session: null }, error: null }),
+    signInWithOAuth: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    signOut: jest.fn().mockResolvedValue({ error: null }),
+    onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } })
+  },
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: { path: 'mock/path' }, error: null }),
+      download: jest.fn().mockResolvedValue({ data: new Blob(), error: null }),
+      remove: jest.fn().mockResolvedValue({ data: null, error: null }),
+      getPublicUrl: jest.fn((path) => ({ data: { publicUrl: `https://mock.supabase.co/bucket/${path}` } }))
+    }))
+  }
+};
+
+module.exports = {
+  supabase,
+  supabaseAdmin,
+  createClient: () => supabase
+};

--- a/tests/fixtures/mockSupabase.js
+++ b/tests/fixtures/mockSupabase.js
@@ -1,0 +1,184 @@
+/**
+ * Mock Supabase Client for Unit Tests
+ * Provides a flexible mock that can be configured per test
+ */
+
+/**
+ * Create a chainable mock query builder
+ */
+const createMockQueryBuilder = (resolvedData = null, resolvedError = null) => {
+  const builder = {
+    _data: resolvedData,
+    _error: resolvedError,
+    _filters: [],
+    _selectFields: null,
+    _single: false,
+    _limit: null,
+    _order: null,
+    
+    select: jest.fn(function(fields) {
+      this._selectFields = fields;
+      return this;
+    }),
+    
+    insert: jest.fn(function(data) {
+      return this;
+    }),
+    
+    update: jest.fn(function(data) {
+      return this;
+    }),
+    
+    delete: jest.fn(function() {
+      return this;
+    }),
+    
+    eq: jest.fn(function(column, value) {
+      this._filters.push({ type: 'eq', column, value });
+      return this;
+    }),
+    
+    neq: jest.fn(function(column, value) {
+      this._filters.push({ type: 'neq', column, value });
+      return this;
+    }),
+    
+    in: jest.fn(function(column, values) {
+      this._filters.push({ type: 'in', column, values });
+      return this;
+    }),
+    
+    is: jest.fn(function(column, value) {
+      this._filters.push({ type: 'is', column, value });
+      return this;
+    }),
+    
+    ilike: jest.fn(function(column, pattern) {
+      this._filters.push({ type: 'ilike', column, pattern });
+      return this;
+    }),
+    
+    or: jest.fn(function(conditions) {
+      this._filters.push({ type: 'or', conditions });
+      return this;
+    }),
+    
+    order: jest.fn(function(column, options) {
+      this._order = { column, ...options };
+      return this;
+    }),
+    
+    limit: jest.fn(function(count) {
+      this._limit = count;
+      return this;
+    }),
+    
+    range: jest.fn(function(from, to) {
+      return this;
+    }),
+    
+    single: jest.fn(function() {
+      this._single = true;
+      return Promise.resolve({
+        data: this._data,
+        error: this._error
+      });
+    }),
+    
+    maybeSingle: jest.fn(function() {
+      this._single = true;
+      return Promise.resolve({
+        data: this._data,
+        error: this._error
+      });
+    }),
+    
+    then: function(resolve, reject) {
+      const result = {
+        data: this._data,
+        error: this._error,
+        count: Array.isArray(this._data) ? this._data.length : (this._data ? 1 : 0)
+      };
+      return Promise.resolve(result).then(resolve, reject);
+    }
+  };
+  
+  // Bind all methods to the builder
+  Object.keys(builder).forEach(key => {
+    if (typeof builder[key] === 'function' && key !== 'then') {
+      builder[key] = builder[key].bind(builder);
+    }
+  });
+  
+  return builder;
+};
+
+/**
+ * Create a mock Supabase client
+ */
+const createMockSupabaseClient = () => {
+  // Store for mocked responses per table
+  const mockResponses = new Map();
+  
+  const client = {
+    // Set mock response for a table
+    setMockResponse: (table, data, error = null) => {
+      mockResponses.set(table, { data, error });
+    },
+    
+    // Clear all mock responses
+    clearMockResponses: () => {
+      mockResponses.clear();
+    },
+    
+    // The from method that returns query builder
+    from: jest.fn((table) => {
+      const response = mockResponses.get(table) || { data: null, error: null };
+      return createMockQueryBuilder(response.data, response.error);
+    }),
+    
+    // RPC calls
+    rpc: jest.fn((functionName, params) => {
+      const response = mockResponses.get(`rpc:${functionName}`) || { data: null, error: null };
+      return Promise.resolve(response);
+    }),
+    
+    // Auth methods
+    auth: {
+      getUser: jest.fn(() => Promise.resolve({ data: { user: null }, error: null })),
+      signInWithPassword: jest.fn(() => Promise.resolve({ data: { user: null, session: null }, error: null })),
+      signOut: jest.fn(() => Promise.resolve({ error: null }))
+    },
+    
+    // Storage methods
+    storage: {
+      from: jest.fn((bucket) => ({
+        upload: jest.fn(() => Promise.resolve({ data: { path: 'mock/path' }, error: null })),
+        download: jest.fn(() => Promise.resolve({ data: new Blob(), error: null })),
+        remove: jest.fn(() => Promise.resolve({ data: null, error: null })),
+        getPublicUrl: jest.fn((path) => ({ data: { publicUrl: `https://mock.supabase.co/${bucket}/${path}` } }))
+      }))
+    }
+  };
+  
+  return client;
+};
+
+/**
+ * Create the default mock module for jest.mock
+ */
+const createSupabaseMock = () => {
+  const mockClient = createMockSupabaseClient();
+  
+  return {
+    supabaseAdmin: mockClient,
+    supabase: mockClient,
+    createClient: () => mockClient
+  };
+};
+
+module.exports = {
+  createMockQueryBuilder,
+  createMockSupabaseClient,
+  createSupabaseMock
+};

--- a/tests/fixtures/testData.js
+++ b/tests/fixtures/testData.js
@@ -1,0 +1,178 @@
+/**
+ * Test Data Fixtures
+ * Provides factory functions for creating test data
+ */
+
+const { v4: uuidv4 } = require('uuid');
+const { faker } = require('@faker-js/faker');
+
+/**
+ * Create a mock user object
+ */
+const createMockUser = (overrides = {}) => ({
+  id: uuidv4(),
+  email: faker.internet.email(),
+  name: faker.person.fullName(),
+  created_at: new Date().toISOString(),
+  ...overrides
+});
+
+/**
+ * Create a mock plan object
+ */
+const createMockPlan = (overrides = {}) => ({
+  id: uuidv4(),
+  title: faker.lorem.sentence(3),
+  description: faker.lorem.paragraph(),
+  owner_id: uuidv4(),
+  status: 'draft',
+  visibility: 'private',
+  is_public: false,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  view_count: 0,
+  ...overrides
+});
+
+/**
+ * Create a mock plan node object
+ */
+const createMockNode = (overrides = {}) => ({
+  id: uuidv4(),
+  plan_id: uuidv4(),
+  parent_id: null,
+  node_type: 'task',
+  title: faker.lorem.sentence(3),
+  description: faker.lorem.paragraph(),
+  status: 'not_started',
+  order_index: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  context: '',
+  agent_instructions: '',
+  acceptance_criteria: '',
+  metadata: {},
+  ...overrides
+});
+
+/**
+ * Create a mock root node for a plan
+ */
+const createMockRootNode = (planId, title, overrides = {}) => createMockNode({
+  plan_id: planId,
+  parent_id: null,
+  node_type: 'root',
+  title: title,
+  order_index: 0,
+  ...overrides
+});
+
+/**
+ * Create a mock phase node
+ */
+const createMockPhaseNode = (planId, parentId, overrides = {}) => createMockNode({
+  plan_id: planId,
+  parent_id: parentId,
+  node_type: 'phase',
+  ...overrides
+});
+
+/**
+ * Create a mock task node
+ */
+const createMockTaskNode = (planId, parentId, overrides = {}) => createMockNode({
+  plan_id: planId,
+  parent_id: parentId,
+  node_type: 'task',
+  ...overrides
+});
+
+/**
+ * Create a mock milestone node
+ */
+const createMockMilestoneNode = (planId, parentId, overrides = {}) => createMockNode({
+  plan_id: planId,
+  parent_id: parentId,
+  node_type: 'milestone',
+  ...overrides
+});
+
+/**
+ * Create a mock activity log entry
+ */
+const createMockActivityLog = (overrides = {}) => ({
+  id: uuidv4(),
+  plan_id: uuidv4(),
+  node_id: uuidv4(),
+  user_id: uuidv4(),
+  activity_type: 'comment',
+  content: faker.lorem.paragraph(),
+  created_at: new Date().toISOString(),
+  metadata: {},
+  ...overrides
+});
+
+/**
+ * Create a mock artifact
+ */
+const createMockArtifact = (overrides = {}) => ({
+  id: uuidv4(),
+  plan_id: uuidv4(),
+  node_id: uuidv4(),
+  user_id: uuidv4(),
+  name: faker.system.fileName(),
+  artifact_type: 'file',
+  content_type: 'text/plain',
+  content: faker.lorem.paragraphs(2),
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  metadata: {},
+  ...overrides
+});
+
+/**
+ * Create a mock Express request object
+ */
+const createMockRequest = (overrides = {}) => ({
+  params: {},
+  query: {},
+  body: {},
+  user: createMockUser(),
+  headers: {
+    'content-type': 'application/json'
+  },
+  ...overrides
+});
+
+/**
+ * Create a mock Express response object
+ */
+const createMockResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
+  res.end = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+/**
+ * Create a mock next function
+ */
+const createMockNext = () => jest.fn();
+
+module.exports = {
+  createMockUser,
+  createMockPlan,
+  createMockNode,
+  createMockRootNode,
+  createMockPhaseNode,
+  createMockTaskNode,
+  createMockMilestoneNode,
+  createMockActivityLog,
+  createMockArtifact,
+  createMockRequest,
+  createMockResponse,
+  createMockNext
+};

--- a/tests/setup/jest.setup.js
+++ b/tests/setup/jest.setup.js
@@ -1,0 +1,31 @@
+/**
+ * Jest Setup - Runs before each test file
+ */
+
+// Extend Jest matchers
+require('jest-extended');
+
+// Set test environment
+process.env.NODE_ENV = 'test';
+
+// Increase timeout for integration tests
+jest.setTimeout(30000);
+
+// Global mock for logger to suppress output during tests
+jest.mock('../../src/utils/logger', () => ({
+  api: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn()
+}));
+
+// Global beforeAll - runs once before all tests
+beforeAll(async () => {
+  // Any global setup
+});
+
+// Global afterAll - runs once after all tests
+afterAll(async () => {
+  // Clean up any global resources
+});

--- a/tests/unit/controllers/node.controller.test.js
+++ b/tests/unit/controllers/node.controller.test.js
@@ -1,0 +1,740 @@
+/**
+ * Unit Tests for Node Controller
+ * Tests CRUD operations for plan nodes
+ */
+
+const { v4: uuidv4 } = require('uuid');
+const {
+  createMockRequest,
+  createMockResponse,
+  createMockNext,
+  createMockUser,
+  createMockPlan,
+  createMockNode,
+  createMockRootNode,
+  createMockPhaseNode,
+  createMockTaskNode
+} = require('../../fixtures/testData');
+
+// Mock dependencies before requiring the controller
+jest.mock('../../../src/config/supabase');
+jest.mock('../../../src/websocket/broadcast', () => ({
+  broadcastPlanUpdate: jest.fn().mockResolvedValue(true)
+}));
+
+const { supabaseAdmin: supabase } = require('../../../src/config/supabase');
+const nodeController = require('../../../src/controllers/node.controller');
+
+describe('Node Controller', () => {
+  let mockUser;
+  let mockPlan;
+  let mockRootNode;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = createMockUser();
+    mockPlan = createMockPlan({ owner_id: mockUser.id });
+    mockRootNode = createMockRootNode(mockPlan.id, mockPlan.title);
+  });
+
+  /**
+   * Helper to setup supabase mock for plan access granted
+   */
+  const setupPlanAccessMock = (ownerId = mockUser.id) => {
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { owner_id: ownerId },
+        error: null
+      })
+    };
+  };
+
+  describe('getNodes', () => {
+    it('should return hierarchical tree structure for authorized user', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const phase = createMockPhaseNode(planId, mockRootNode.id, { order_index: 0 });
+      const task1 = createMockTaskNode(planId, phase.id, { order_index: 0 });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        // First two calls are for checkPlanAccess
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            order: jest.fn().mockResolvedValue({
+              data: [
+                { ...mockRootNode, parent_id: null },
+                { ...phase, parent_id: mockRootNode.id },
+                { ...task1, parent_id: phase.id }
+              ],
+              error: null
+            })
+          };
+        }
+        
+        // plan_collaborators check
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.getNodes(req, res, next);
+
+      expect(res.json).toHaveBeenCalled();
+      const tree = res.json.mock.calls[0][0];
+      expect(Array.isArray(tree)).toBe(true);
+    });
+
+    it('should return 403 when user has no access', async () => {
+      const planId = mockPlan.id;
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.getNodes(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('getNode', () => {
+    it('should return a specific node for authorized user', async () => {
+      const planId = mockPlan.id;
+      const nodeId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const taskNode = createMockTaskNode(planId, mockRootNode.id, { id: nodeId });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: taskNode,
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.getNode(req, res, next);
+
+      expect(res.json).toHaveBeenCalled();
+      const responseData = res.json.mock.calls[0][0];
+      expect(responseData.id).toBe(nodeId);
+    });
+
+    it('should return 404 when node not found', async () => {
+      const planId = mockPlan.id;
+      const nodeId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.getNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Node not found' });
+    });
+
+    it('should return 403 when user has no access to plan', async () => {
+      const planId = mockPlan.id;
+      const nodeId = uuidv4();
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.getNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('createNode', () => {
+    it('should return 400 when title is missing', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: {
+          parent_id: mockRootNode.id,
+          node_type: 'task'
+          // title is missing
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.createNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('title') })
+      );
+    });
+
+    it('should return 400 when node_type is missing', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: {
+          parent_id: mockRootNode.id,
+          title: 'Test Task'
+          // node_type is missing
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.createNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('type') })
+      );
+    });
+
+    it('should return 400 when trying to create root node', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: {
+          parent_id: mockRootNode.id,
+          node_type: 'root',
+          title: 'Another Root'
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.createNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('root') })
+      );
+    });
+
+    it('should return 403 when user has no edit access', async () => {
+      const planId = mockPlan.id;
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: {
+          parent_id: mockRootNode.id,
+          node_type: 'task',
+          title: 'Test Task'
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { role: 'viewer' },  // Viewer can't create
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.createNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('updateNode', () => {
+    it('should return 403 when user has no edit access', async () => {
+      const planId = mockPlan.id;
+      const nodeId = uuidv4();
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId },
+        body: { title: 'Updated Title' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { role: 'viewer' },
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.updateNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it('should return 404 when node not found', async () => {
+      const planId = mockPlan.id;
+      const nodeId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId },
+        body: { title: 'Updated Title' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.updateNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should return 400 when trying to change root node type', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId, nodeId: mockRootNode.id },
+        body: { node_type: 'task' }  // Trying to change root to task
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (callCount <= 2 && table === 'plans') {
+          return setupPlanAccessMock();
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { node_type: 'root' },  // Node is root type
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: { code: 'PGRST116' }
+          })
+        };
+      });
+
+      await nodeController.updateNode(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('root') })
+      );
+    });
+  });
+
+  describe('checkPlanAccess helper (via getNodes)', () => {
+    it('should grant access to plan owner', async () => {
+      const planId = mockPlan.id;
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: mockUser.id },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            order: jest.fn().mockResolvedValue({
+              data: [mockRootNode],
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.getNodes(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalled();
+    });
+
+    it('should grant access to collaborator with proper role', async () => {
+      const planId = mockPlan.id;
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { role: 'editor' },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            order: jest.fn().mockResolvedValue({
+              data: [mockRootNode],
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.getNodes(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalledWith(403);
+    });
+
+    it('should deny access when user is neither owner nor collaborator', async () => {
+      const planId = mockPlan.id;
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await nodeController.getNodes(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+});

--- a/tests/unit/controllers/plan.controller.test.js
+++ b/tests/unit/controllers/plan.controller.test.js
@@ -1,0 +1,790 @@
+/**
+ * Unit Tests for Plan Controller
+ * Tests core CRUD operations for plans
+ */
+
+const { v4: uuidv4 } = require('uuid');
+const {
+  createMockRequest,
+  createMockResponse,
+  createMockNext,
+  createMockUser,
+  createMockPlan,
+  createMockRootNode
+} = require('../../fixtures/testData');
+
+// Mock dependencies before requiring the controller
+jest.mock('../../../src/config/supabase');
+jest.mock('../../../src/websocket/broadcast', () => ({
+  broadcastPlanUpdate: jest.fn().mockResolvedValue(true),
+  broadcastToAll: jest.fn().mockResolvedValue(true)
+}));
+
+const { supabaseAdmin: supabase } = require('../../../src/config/supabase');
+const planController = require('../../../src/controllers/plan.controller');
+
+describe('Plan Controller', () => {
+  let mockUser;
+  let mockPlan;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = createMockUser();
+    mockPlan = createMockPlan({ owner_id: mockUser.id });
+  });
+
+  describe('createPlan', () => {
+    it('should create a plan successfully with valid title', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        body: {
+          title: 'Test Plan',
+          description: 'Test description'
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      // Mock supabase responses
+      const createdPlan = {
+        id: expect.any(String),
+        title: 'Test Plan',
+        description: 'Test description',
+        status: 'draft',
+        owner_id: mockUser.id,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date)
+      };
+
+      // Mock chain for plan insert
+      const planInsertMock = {
+        insert: jest.fn().mockResolvedValue({ error: null })
+      };
+      
+      // Mock chain for node insert
+      const nodeInsertMock = {
+        insert: jest.fn().mockResolvedValue({ error: null })
+      };
+      
+      // Mock chain for select/fetch
+      const selectMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: {
+            id: uuidv4(),
+            title: 'Test Plan',
+            description: 'Test description',
+            status: 'draft',
+            owner_id: mockUser.id,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
+          },
+          error: null
+        })
+      };
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        if (table === 'plans') {
+          // First call is insert, second call is select
+          if (callCount === 1) return planInsertMock;
+          return selectMock;
+        }
+        if (table === 'plan_nodes') {
+          return nodeInsertMock;
+        }
+        return planInsertMock;
+      });
+
+      await planController.createPlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalled();
+      const responseData = res.json.mock.calls[0][0];
+      expect(responseData.title).toBe('Test Plan');
+      expect(responseData.progress).toBe(0);
+    });
+
+    it('should return 400 when title is missing', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        body: {
+          description: 'Test description'
+          // title is missing
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await planController.createPlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Title is required' });
+    });
+
+    it('should handle database errors on plan creation', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        body: {
+          title: 'Test Plan',
+          description: 'Test description'
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockReturnValue({
+        insert: jest.fn().mockResolvedValue({
+          error: { message: 'Database error' }
+        })
+      });
+
+      await planController.createPlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Database error' });
+    });
+
+    it('should use default status "draft" when not provided', async () => {
+      const req = createMockRequest({
+        user: mockUser,
+        body: {
+          title: 'Test Plan'
+        }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      let insertedPlan = null;
+      const planInsertMock = {
+        insert: jest.fn().mockImplementation((data) => {
+          insertedPlan = data[0];
+          return Promise.resolve({ error: null });
+        })
+      };
+      
+      const nodeInsertMock = {
+        insert: jest.fn().mockResolvedValue({ error: null })
+      };
+
+      const selectMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: {
+            id: uuidv4(),
+            title: 'Test Plan',
+            description: '',
+            status: 'draft',
+            owner_id: mockUser.id
+          },
+          error: null
+        })
+      };
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        if (table === 'plans') {
+          if (callCount === 1) return planInsertMock;
+          return selectMock;
+        }
+        return nodeInsertMock;
+      });
+
+      await planController.createPlan(req, res, next);
+
+      expect(insertedPlan.status).toBe('draft');
+    });
+  });
+
+  describe('getPlan', () => {
+    it('should return plan with root node for owner', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const planData = createMockPlan({ id: planId, owner_id: mockUser.id });
+      const rootNode = createMockRootNode(planId, planData.title);
+
+      // Mock for checkPlanAccess
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (table === 'plans') {
+          // First call: checkPlanAccess ownership check
+          if (callCount === 1) {
+            return {
+              select: jest.fn().mockReturnThis(),
+              eq: jest.fn().mockReturnThis(),
+              single: jest.fn().mockResolvedValue({
+                data: { owner_id: mockUser.id },
+                error: null
+              })
+            };
+          }
+          // Second call: getPlan fetch
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: planData,
+              error: null
+            })
+          };
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: rootNode,
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.getPlan(req, res, next);
+
+      expect(res.json).toHaveBeenCalled();
+      const responseData = res.json.mock.calls[0][0];
+      expect(responseData.id).toBe(planId);
+      expect(responseData.root_node).toBeDefined();
+      expect(responseData.is_owner).toBe(true);
+    });
+
+    it('should return 403 when user has no access', async () => {
+      const planId = uuidv4();
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      // Mock: user is not the owner
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.getPlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('access') })
+      );
+    });
+
+    it('should return 404 when plan not found', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      // Mock: plan not found in checkPlanAccess
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST116' }
+        })
+      });
+
+      await planController.getPlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('updatePlan', () => {
+    it('should update plan title successfully', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: { title: 'Updated Title' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const updatedPlan = createMockPlan({
+        id: planId,
+        owner_id: mockUser.id,
+        title: 'Updated Title'
+      });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (table === 'plans') {
+          // checkPlanAccess call
+          if (callCount === 1) {
+            return {
+              select: jest.fn().mockReturnThis(),
+              eq: jest.fn().mockReturnThis(),
+              single: jest.fn().mockResolvedValue({
+                data: { owner_id: mockUser.id },
+                error: null
+              })
+            };
+          }
+          // update call
+          return {
+            update: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            select: jest.fn().mockResolvedValue({
+              data: [updatedPlan],
+              error: null
+            })
+          };
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            update: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({ data: [], error: null })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.updatePlan(req, res, next);
+
+      expect(res.json).toHaveBeenCalled();
+      const responseData = res.json.mock.calls[0][0];
+      expect(responseData.title).toBe('Updated Title');
+    });
+
+    it('should return 403 when user is not owner or admin', async () => {
+      const planId = uuidv4();
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        body: { title: 'Updated Title' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      // User is not owner
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: otherUserId },
+              error: null
+            })
+          };
+        }
+        
+        // User is viewer, not admin
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { role: 'viewer' },
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.updatePlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  describe('deletePlan', () => {
+    it('should delete plan when user is owner', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            delete: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: { owner_id: mockUser.id },
+              error: null
+            })
+          };
+        }
+        
+        // Mock all related table deletes
+        return {
+          delete: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          match: jest.fn().mockResolvedValue({ error: null })
+        };
+      });
+
+      await planController.deletePlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+
+    it('should archive plan when archive=true', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: { archive: 'true' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const archivedPlan = createMockPlan({
+        id: planId,
+        owner_id: mockUser.id,
+        status: 'archived'
+      });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (table === 'plans') {
+          // First call: ownership check
+          if (callCount === 1) {
+            return {
+              select: jest.fn().mockReturnThis(),
+              eq: jest.fn().mockReturnThis(),
+              single: jest.fn().mockResolvedValue({
+                data: { owner_id: mockUser.id },
+                error: null
+              })
+            };
+          }
+          // Second call: update to archive
+          if (callCount === 2) {
+            return {
+              update: jest.fn().mockReturnThis(),
+              eq: jest.fn().mockResolvedValue({ error: null })
+            };
+          }
+          // Third call: fetch archived plan for broadcast
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: archivedPlan,
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.deletePlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('archived') })
+      );
+    });
+
+    it('should return 403 when user is not owner', async () => {
+      const planId = uuidv4();
+      const otherUserId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { owner_id: otherUserId },
+          error: null
+        })
+      });
+
+      await planController.deletePlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('owner') })
+      );
+    });
+
+    it('should return 404 when plan not found', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId },
+        query: {}
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST116' }
+        })
+      });
+
+      await planController.deletePlan(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('listPlans', () => {
+    it('should return empty array when user has no plans', async () => {
+      const req = createMockRequest({ user: mockUser });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockResolvedValue({ data: [], error: null })
+        };
+      });
+
+      await planController.listPlans(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('should return owned plans with owner role', async () => {
+      const req = createMockRequest({ user: mockUser });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const ownedPlan = createMockPlan({ owner_id: mockUser.id });
+
+      let nodeQueryCount = 0;
+      supabase.from.mockImplementation((table) => {
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [ownedPlan],
+              error: null
+            })
+          };
+        }
+        if (table === 'plan_collaborators') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          };
+        }
+        // plan_nodes for progress calculation
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: uuidv4(), status: 'not_started' }],
+              error: null
+            })
+          };
+        }
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockResolvedValue({ data: [], error: null })
+        };
+      });
+
+      await planController.listPlans(req, res, next);
+
+      expect(res.json).toHaveBeenCalled();
+      const responseData = res.json.mock.calls[0][0];
+      expect(responseData.length).toBe(1);
+      expect(responseData[0].role).toBe('owner');
+      expect(responseData[0]).toHaveProperty('progress');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const req = createMockRequest({ user: mockUser });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'Database connection failed' }
+        })
+      });
+
+      await planController.listPlans(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Database connection failed' })
+      );
+    });
+  });
+
+  describe('calculatePlanProgress', () => {
+    // Testing through integration as it's a private function
+    // Progress is included in getPlan and listPlans responses
+    
+    it('should calculate 0% for plans with no completed nodes', async () => {
+      const planId = uuidv4();
+      const req = createMockRequest({
+        user: mockUser,
+        params: { id: planId }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const planData = createMockPlan({ id: planId, owner_id: mockUser.id });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        callCount++;
+        
+        if (table === 'plans') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: callCount === 1 ? { owner_id: mockUser.id } : planData,
+              error: null
+            })
+          };
+        }
+        
+        if (table === 'plan_nodes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: createMockRootNode(planId, planData.title),
+              error: null
+            }),
+            // For calculatePlanProgress
+            then: (resolve) => resolve({
+              data: [
+                { id: uuidv4(), status: 'not_started' },
+                { id: uuidv4(), status: 'not_started' }
+              ],
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await planController.getPlan(req, res, next);
+
+      // Progress calculation happens, though mocking makes it hard to verify exact value
+      expect(res.json).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/middleware/auth.middleware.test.js
+++ b/tests/unit/middleware/auth.middleware.test.js
@@ -1,0 +1,581 @@
+/**
+ * Unit Tests for Authentication Middleware
+ * Tests JWT and API token authentication
+ */
+
+const crypto = require('crypto');
+const {
+  createMockRequest,
+  createMockResponse,
+  createMockNext,
+  createMockUser
+} = require('../../fixtures/testData');
+
+// Mock dependencies before requiring the middleware
+jest.mock('../../../src/config/supabase');
+
+const { supabase, supabaseAdmin } = require('../../../src/config/supabase');
+const { authenticate } = require('../../../src/middleware/auth.middleware');
+
+describe('Authentication Middleware', () => {
+  let mockUser;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = createMockUser();
+    
+    // Default mock implementations
+    supabase.auth = {
+      setSession: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    };
+    
+    supabaseAdmin.auth = {
+      getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    };
+    
+    supabaseAdmin.from = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      update: jest.fn().mockReturnThis()
+    });
+  });
+
+  describe('Missing Authorization Header', () => {
+    it('should return 401 when no authorization header provided', async () => {
+      const req = createMockRequest({
+        headers: {} // No authorization header
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Invalid Authorization Format', () => {
+    it('should return 401 for malformed authorization header', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'invalid' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid authentication format' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for unsupported authentication scheme', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Basic sometoken' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('Invalid authentication format')
+        })
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Supabase JWT Authentication (Bearer)', () => {
+    it('should authenticate valid Supabase JWT', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid.jwt.token' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.auth.setSession.mockResolvedValue({ data: {}, error: null });
+      supabase.auth.getUser.mockResolvedValue({
+        data: {
+          user: {
+            id: mockUser.id,
+            email: mockUser.email,
+            user_metadata: { name: mockUser.name }
+          }
+        },
+        error: null
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toBeDefined();
+      expect(req.user.id).toBe(mockUser.id);
+      expect(req.user.email).toBe(mockUser.email);
+      expect(req.user.authMethod).toBe('supabase_jwt');
+    });
+
+    it('should fallback to admin verification when setSession fails', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid.jwt.token' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.auth.setSession.mockResolvedValue({
+        data: null,
+        error: { message: 'Session expired' }
+      });
+      
+      supabaseAdmin.auth.getUser.mockResolvedValue({
+        data: {
+          user: {
+            id: mockUser.id,
+            email: mockUser.email,
+            user_metadata: { name: mockUser.name }
+          }
+        },
+        error: null
+      });
+
+      await authenticate(req, res, next);
+
+      expect(supabaseAdmin.auth.getUser).toHaveBeenCalledWith('valid.jwt.token');
+      expect(next).toHaveBeenCalled();
+      expect(req.user.authMethod).toBe('supabase_jwt');
+    });
+
+    it('should return 401 for invalid JWT', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer invalid.jwt.token' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.auth.setSession.mockResolvedValue({
+        data: null,
+        error: { message: 'Invalid token' }
+      });
+      
+      supabaseAdmin.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should sync GitHub profile for GitHub OAuth users', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer valid.jwt.token' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const githubUser = {
+        id: mockUser.id,
+        email: mockUser.email,
+        user_metadata: {
+          name: mockUser.name,
+          user_name: 'github_user',
+          avatar_url: 'https://github.com/avatar.png',
+          provider_id: '12345'
+        },
+        app_metadata: {
+          provider: 'github'
+        }
+      };
+
+      supabase.auth.setSession.mockResolvedValue({ data: {}, error: null });
+      supabase.auth.getUser.mockResolvedValue({
+        data: { user: githubUser },
+        error: null
+      });
+
+      const updateMock = jest.fn().mockReturnThis();
+      const eqMock = jest.fn().mockResolvedValue({ error: null });
+      
+      supabaseAdmin.from.mockReturnValue({
+        update: updateMock,
+        eq: eqMock,
+        select: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: null, error: null })
+      });
+
+      await authenticate(req, res, next);
+
+      expect(supabaseAdmin.from).toHaveBeenCalledWith('users');
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('API Token Authentication (ApiKey scheme)', () => {
+    const generateMockApiToken = () => {
+      // Generate a 64-char hex token like the real implementation
+      return crypto.randomBytes(32).toString('hex');
+    };
+
+    it('should authenticate valid API token with ApiKey scheme', async () => {
+      const apiToken = generateMockApiToken();
+      
+      const req = createMockRequest({
+        headers: { authorization: `ApiKey ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const tokenData = {
+        user_id: mockUser.id,
+        permissions: ['read', 'write'],
+        revoked: false,
+        id: 'token-id-123',
+        last_used: new Date().toISOString()
+      };
+
+      // Create chainable mocks for each table
+      const apiTokensMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: tokenData,
+          error: null
+        }),
+        update: jest.fn().mockReturnThis(),
+        then: jest.fn((resolve) => resolve({ error: null }))
+      };
+      
+      const usersMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: mockUser,
+          error: null
+        })
+      };
+
+      supabaseAdmin.from.mockImplementation((table) => {
+        if (table === 'api_tokens') return apiTokensMock;
+        if (table === 'users') return usersMock;
+        return apiTokensMock;
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.user).toBeDefined();
+      expect(req.user.id).toBe(mockUser.id);
+      expect(req.user.authMethod).toBe('api_key');
+      expect(req.user.permissions).toEqual(['read', 'write']);
+    });
+
+    it('should return 401 for revoked API token', async () => {
+      const apiToken = generateMockApiToken();
+      
+      const req = createMockRequest({
+        headers: { authorization: `ApiKey ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabaseAdmin.from.mockImplementation((table) => {
+        if (table === 'api_tokens') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: {
+                user_id: mockUser.id,
+                permissions: [],
+                revoked: true,  // Token is revoked
+                id: 'token-id-123'
+              },
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'API token has been revoked' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for non-existent API token', async () => {
+      const apiToken = generateMockApiToken();
+      
+      const req = createMockRequest({
+        headers: { authorization: `ApiKey ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabaseAdmin.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST116' }
+        })
+      });
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API token' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when user not found for API token', async () => {
+      const apiToken = generateMockApiToken();
+      
+      const req = createMockRequest({
+        headers: { authorization: `ApiKey ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabaseAdmin.from.mockImplementation((table) => {
+        if (table === 'api_tokens') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: {
+                user_id: 'non-existent-user',
+                permissions: [],
+                revoked: false,
+                id: 'token-id-123'
+              },
+              error: null
+            })
+          };
+        }
+        
+        if (table === 'users') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { code: 'PGRST116' }
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null })
+        };
+      });
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'User not found for API token' });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('API Token Authentication (Bearer scheme for hex tokens)', () => {
+    const generateMockApiToken = () => {
+      return crypto.randomBytes(32).toString('hex');
+    };
+
+    it('should try API token auth for 64-char hex Bearer tokens', async () => {
+      const apiToken = generateMockApiToken();
+      
+      const req = createMockRequest({
+        headers: { authorization: `Bearer ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const tokenData = {
+        user_id: mockUser.id,
+        permissions: ['read'],
+        revoked: false,
+        id: 'token-id-456'
+      };
+
+      // Create chainable mocks for each table
+      const apiTokensMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: tokenData,
+          error: null
+        }),
+        update: jest.fn().mockReturnThis(),
+        then: jest.fn((resolve) => resolve({ error: null }))
+      };
+      
+      const usersMock = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: mockUser,
+          error: null
+        })
+      };
+
+      supabaseAdmin.from.mockImplementation((table) => {
+        if (table === 'api_tokens') return apiTokensMock;
+        if (table === 'users') return usersMock;
+        return apiTokensMock;
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.user.authMethod).toBe('api_key');
+    });
+
+    it('should fallback to JWT auth if hex token is not a valid API token', async () => {
+      const hexToken = crypto.randomBytes(32).toString('hex');
+      
+      const req = createMockRequest({
+        headers: { authorization: `Bearer ${hexToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      // API token lookup fails
+      supabaseAdmin.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST116' }
+        })
+      });
+
+      // But Supabase JWT auth succeeds (unlikely for hex string but testing fallback)
+      supabase.auth.setSession.mockResolvedValue({ data: {}, error: null });
+      supabase.auth.getUser.mockResolvedValue({
+        data: {
+          user: {
+            id: mockUser.id,
+            email: mockUser.email,
+            user_metadata: { name: mockUser.name }
+          }
+        },
+        error: null
+      });
+
+      await authenticate(req, res, next);
+
+      // Should have tried JWT auth after API token failed
+      expect(supabase.auth.setSession).toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle database errors gracefully', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer some.jwt.token' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      supabase.auth.setSession.mockRejectedValue(new Error('Database connection failed'));
+
+      await authenticate(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Authentication failed' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty token after Bearer', async () => {
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer ' }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await authenticate(req, res, next);
+
+      // Should try to verify empty string as token and fail
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should update last_used timestamp for API tokens', async () => {
+      const apiToken = crypto.randomBytes(32).toString('hex');
+      
+      const req = createMockRequest({
+        headers: { authorization: `ApiKey ${apiToken}` }
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      const tokenId = 'token-update-test';
+      const updateMock = jest.fn().mockReturnThis();
+      const updateEqMock = jest.fn().mockReturnValue(
+        Promise.resolve({ error: null })
+      );
+
+      supabaseAdmin.from.mockImplementation((table) => {
+        if (table === 'api_tokens') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: {
+                user_id: mockUser.id,
+                permissions: [],
+                revoked: false,
+                id: tokenId
+              },
+              error: null
+            }),
+            update: updateMock,
+            then: jest.fn()
+          };
+        }
+        
+        if (table === 'users') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: mockUser,
+              error: null
+            })
+          };
+        }
+        
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: null, error: null }),
+          update: updateMock
+        };
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      // The last_used update happens asynchronously, so we just verify auth succeeded
+      expect(req.user).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR establishes comprehensive testing infrastructure for the agent-planner project and adds unit tests for core controllers.

## Changes

### Testing Infrastructure
- **jest.config.js** - Jest configuration with unit/integration test projects
- **tests/setup/jest.setup.js** - Global test setup with logger mocks
- **tests/fixtures/testData.js** - Factory functions for test data (users, plans, nodes, etc.)
- **tests/fixtures/mockSupabase.js** - Reusable Supabase mock utilities
- **src/config/__mocks__/supabase.js** - Auto-mock for Supabase client

### Unit Tests Added (48 tests total)

#### Plan Controller (17 tests)
- `createPlan`: Validation, success cases, error handling
- `getPlan`: Authorization, data retrieval, 404 handling
- `updatePlan`: Partial updates, permission checks
- `deletePlan`: Soft delete (archive), hard delete, owner verification
- `listPlans`: Empty results, owned plans, database error handling

#### Node Controller (15 tests)
- `getNodes`: Tree structure building, authorization
- `getNode`: Retrieval, 404 handling, access control
- `createNode`: Validation (title, node_type, root node restriction)
- `updateNode`: Authorization, 404 handling, root node protection
- `checkPlanAccess`: Owner access, collaborator roles, denial cases

#### Auth Middleware (16 tests)
- Missing/invalid authorization header handling
- Supabase JWT authentication (Bearer scheme)
- API token authentication (ApiKey scheme)
- Bearer scheme for 64-char hex API tokens
- Edge cases: database errors, empty tokens
- GitHub profile sync for OAuth users

## Test Coverage

Current coverage focuses on the most critical components:
- **auth.middleware.js**: 91% line coverage
- **plan.controller.js**: Key CRUD operations
- **node.controller.js**: Key CRUD operations with access control

## How to Run

```bash
# Run all unit tests
npm test -- --testPathPattern="tests/unit"

# Run with coverage
npm test -- --coverage --testPathPattern="tests/unit"
```

## Next Steps

Future PRs can add:
- Integration tests with test database
- E2E tests for critical user flows
- Tests for remaining controllers (artifact, search, activity, etc.)

---

Addresses: Add Core Test Coverage task from AgentPlanner Improvement Roadmap