### PR TITLE
chore: remove obsolete test-search stub

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -123,6 +123,8 @@ Get active and typing users for a specific node
 #### GET /debug/tokens
 Debug endpoint to view all tokens for current user including revoked ones
 
+Only the token debug endpoint is supported; the legacy test-search route has been removed.
+
 
 ### Nodes
 
@@ -264,4 +266,3 @@ Swagger UI interface for exploring and testing the API
 
 #### GET /api-docs-json
 OpenAPI specification in JSON format
-

--- a/src/routes/debug.routes.js
+++ b/src/routes/debug.routes.js
@@ -27,6 +27,4 @@ const { supabaseAdmin } = require('../config/supabase');
  */
 router.get('/tokens', authenticate, debugController.debugTokens);
 
-// Debug test-search route has been removed as per recommendations
-
 module.exports = router;

--- a/src/test-search.js
+++ b/src/test-search.js
@@ -1,3 +1,0 @@
-// This file has been removed as per code review recommendations
-// The search functionality should use the database function search_plan instead
-// of implementing duplicate logic in JavaScript.


### PR DESCRIPTION
### Motivation

- Remove an unused test stub and leftover debug references to avoid duplicated search logic and developer confusion.
- Keep documentation accurate by noting that only the `GET /debug/tokens` debug endpoint is supported and the legacy test-search route has been removed.

### Description

- Delete the obsolete file `src/test-search.js` which contained a deprecated stub.
- Remove the leftover comment about the removed route from `src/routes/debug.routes.js`.
- Update `docs/API.md` to document that the legacy test-search debug route has been removed and that only `GET /debug/tokens` remains supported.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f29a4c508332a6cac86f71a67b1d)