### PR TITLE
Phase 3: Agent Task Request System (Heartbeat Polling)

### DIFF
--- a/src/db/sql/00025_add_agent_request_fields.sql
+++ b/src/db/sql/00025_add_agent_request_fields.sql
@@ -1,0 +1,27 @@
+-- Migration: Add Agent Request Fields to Plan Nodes
+-- Purpose: Enable users to request agent assistance on tasks
+
+-- Add agent request type enum
+CREATE TYPE agent_request_type AS ENUM ('start', 'review', 'help', 'continue');
+
+-- Add agent request fields to plan_nodes
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS agent_requested agent_request_type;
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS agent_requested_at TIMESTAMPTZ;
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS agent_requested_by UUID REFERENCES auth.users(id);
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS agent_request_message TEXT;
+
+-- Index for efficient querying of requested tasks
+CREATE INDEX IF NOT EXISTS idx_plan_nodes_agent_requested 
+  ON plan_nodes(agent_requested) 
+  WHERE agent_requested IS NOT NULL;
+
+-- Index for finding requests by user
+CREATE INDEX IF NOT EXISTS idx_plan_nodes_agent_requested_by 
+  ON plan_nodes(agent_requested_by) 
+  WHERE agent_requested_by IS NOT NULL;
+
+-- Comments
+COMMENT ON COLUMN plan_nodes.agent_requested IS 'Type of agent assistance requested: start (begin work), review (check work), help (provide guidance), continue (resume work)';
+COMMENT ON COLUMN plan_nodes.agent_requested_at IS 'When the agent assistance was requested';
+COMMENT ON COLUMN plan_nodes.agent_requested_by IS 'User who requested agent assistance';
+COMMENT ON COLUMN plan_nodes.agent_request_message IS 'Optional message/context for the agent request';

--- a/src/routes/node.routes.js
+++ b/src/routes/node.routes.js
@@ -895,4 +895,91 @@ const activitiesController = require('../controllers/activities.controller');
  */
 router.get('/:id/nodes/:nodeId/activities', authenticate, activitiesController.getNodeActivities);
 
+/**
+ * Agent Request Endpoints
+ */
+
+/**
+ * @swagger
+ * /plans/{id}/nodes/{nodeId}/request-agent:
+ *   post:
+ *     summary: Request agent assistance on a task
+ *     description: Mark a task as needing agent attention. Agent will pick this up during heartbeat polling.
+ *     tags: [Nodes]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The plan ID
+ *       - in: path
+ *         name: nodeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The node ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - request_type
+ *             properties:
+ *               request_type:
+ *                 type: string
+ *                 enum: [start, review, help, continue]
+ *                 description: Type of assistance needed
+ *               message:
+ *                 type: string
+ *                 maxLength: 1000
+ *                 description: Optional context for the agent
+ *     responses:
+ *       200:
+ *         description: Agent request created
+ *       400:
+ *         description: Invalid input
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Node not found
+ */
+router.post('/:id/nodes/:nodeId/request-agent', authenticate, nodeController.requestAgent);
+
+/**
+ * @swagger
+ * /plans/{id}/nodes/{nodeId}/request-agent:
+ *   delete:
+ *     summary: Clear agent request on a task
+ *     description: Remove the agent assistance request from a task
+ *     tags: [Nodes]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The plan ID
+ *       - in: path
+ *         name: nodeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The node ID
+ *     responses:
+ *       200:
+ *         description: Agent request cleared
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Node not found
+ */
+router.delete('/:id/nodes/:nodeId/request-agent', authenticate, nodeController.clearAgentRequest);
+
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -78,4 +78,44 @@ router.get('/', authenticate, userController.listUsers);
  */
 router.get('/search', authenticate, userController.searchUsers);
 
+/**
+ * @swagger
+ * /users/my-tasks:
+ *   get:
+ *     summary: Get tasks assigned to or requested for the current user/agent
+ *     description: |
+ *       Returns tasks where:
+ *       - User is assigned (via plan_node_assignments)
+ *       - Agent assistance was requested (agent_requested is set)
+ *       
+ *       Use `requested=true` to filter only agent-requested tasks.
+ *       Agents should poll this endpoint during heartbeat.
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: requested
+ *         schema:
+ *           type: boolean
+ *         description: Only return tasks with agent_requested set
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [not_started, in_progress, completed, blocked]
+ *         description: Filter by task status
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *     responses:
+ *       200:
+ *         description: List of tasks
+ *       401:
+ *         description: Authentication required
+ */
+router.get('/my-tasks', authenticate, userController.getMyTasks);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
Enables users to request agent assistance on tasks, which agents can discover via polling during heartbeat.

## Database Changes
Migration `00025_add_agent_request_fields.sql`:
- `agent_requested` - enum: start, review, help, continue
- `agent_requested_at` - timestamp
- `agent_requested_by` - user who requested
- `agent_request_message` - optional context

## New Endpoints

### Request Agent Help
```
POST /plans/:id/nodes/:nodeId/request-agent
{
  "request_type": "start",  // start|review|help|continue
  "message": "Please implement the login feature"  // optional
}
```

### Clear Request
```
DELETE /plans/:id/nodes/:nodeId/request-agent
```

### Poll for Tasks (Agent Heartbeat)
```
GET /users/my-tasks?requested=true
→ { tasks: [...], total: N }
```

## Agent Workflow
1. User clicks 'Ask Agent' in UI → sets agent_requested
2. Agent polls `/my-tasks?requested=true` during heartbeat
3. Agent picks up task, sets status to in_progress
4. Agent does work, logs progress
5. Agent marks complete or requests human review

## Request Types
| Type | When to Use |
|------|-------------|
| `start` | Begin work on this task |
| `review` | Check/review completed work |
| `help` | Provide guidance/suggestions |
| `continue` | Resume interrupted work |