### PR TITLE
feat: Agent Capability Tags - Backend

### DIFF
--- a/src/db/sql/00026_add_capability_tags.sql
+++ b/src/db/sql/00026_add_capability_tags.sql
@@ -1,0 +1,7 @@
+-- Migration: Add capability_tags to users table
+-- Allows agents/users to declare their capabilities (e.g., "coding", "research", "writing")
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS capability_tags TEXT[] DEFAULT '{}';
+
+-- Index for efficient tag-based queries
+CREATE INDEX IF NOT EXISTS idx_users_capability_tags ON users USING GIN (capability_tags);

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -118,4 +118,95 @@ router.get('/search', authenticate, userController.searchUsers);
  */
 router.get('/my-tasks', authenticate, userController.getMyTasks);
 
+/**
+ * @swagger
+ * /users/capabilities:
+ *   get:
+ *     summary: Get capability tags for the current user
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Capability tags
+ */
+router.get('/capabilities', authenticate, userController.getCapabilityTags);
+
+/**
+ * @swagger
+ * /users/capabilities:
+ *   put:
+ *     summary: Update capability tags for the current user
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               capability_tags:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Updated capability tags
+ */
+router.put('/capabilities', authenticate, userController.updateCapabilityTags);
+
+/**
+ * @swagger
+ * /users/capabilities/search:
+ *   get:
+ *     summary: Search users by capability tags
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: tags
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Comma-separated capability tags
+ *       - in: query
+ *         name: match
+ *         schema:
+ *           type: string
+ *           enum: [any, all]
+ *           default: any
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Users matching capability tags
+ */
+router.get('/capabilities/search', authenticate, userController.searchByCapabilities);
+
+/**
+ * @swagger
+ * /users/{userId}/capabilities:
+ *   get:
+ *     summary: Get capability tags for a specific user
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Capability tags for the user
+ */
+router.get('/:userId/capabilities', authenticate, userController.getCapabilityTags);
+
 module.exports = router;


### PR DESCRIPTION
## Agent Capability Tags

Adds a system where agents/users can declare their capabilities (tags like 'coding', 'research', 'writing') so tasks can be matched to the right agent.

### Changes
- **Migration 00026**: Adds `capability_tags` TEXT[] column to users table with GIN index
- **GET /users/capabilities**: Get current user's tags
- **PUT /users/capabilities**: Update current user's tags (normalized, deduplicated)
- **GET /users/capabilities/search**: Search users by tags (supports `any`/`all` matching)
- **GET /users/:userId/capabilities**: Get specific user's tags
- Profile endpoint now includes `capability_tags` field

Part of Phase 5: Multi-Agent Coordination
Plan: OpenClaw Agent Integration Roadmap