### PR TITLE
feat: Task Assignment to Agents - Backend

### DIFF
--- a/src/db/sql/00027_add_agent_assignment.sql
+++ b/src/db/sql/00027_add_agent_assignment.sql
@@ -1,0 +1,9 @@
+-- Migration: Add assigned_agent_id to plan_nodes for explicit agent assignment
+-- This is separate from node_assignments (which tracks human collaborators)
+
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS assigned_agent_id UUID REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS assigned_agent_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE plan_nodes ADD COLUMN IF NOT EXISTS assigned_agent_by UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- Index for finding tasks assigned to a specific agent
+CREATE INDEX IF NOT EXISTS idx_plan_nodes_assigned_agent ON plan_nodes(assigned_agent_id) WHERE assigned_agent_id IS NOT NULL;

--- a/src/routes/node.routes.js
+++ b/src/routes/node.routes.js
@@ -982,4 +982,72 @@ router.post('/:id/nodes/:nodeId/request-agent', authenticate, nodeController.req
  */
 router.delete('/:id/nodes/:nodeId/request-agent', authenticate, nodeController.clearAgentRequest);
 
+/**
+ * @swagger
+ * /{id}/nodes/{nodeId}/assign-agent:
+ *   post:
+ *     summary: Assign an agent to a task
+ *     tags: [Nodes]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: nodeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               agent_id:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Agent assigned
+ */
+router.post('/:id/nodes/:nodeId/assign-agent', authenticate, nodeController.assignAgent);
+
+/**
+ * @swagger
+ * /{id}/nodes/{nodeId}/assign-agent:
+ *   delete:
+ *     summary: Unassign an agent from a task
+ *     tags: [Nodes]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       204:
+ *         description: Agent unassigned
+ */
+router.delete('/:id/nodes/:nodeId/assign-agent', authenticate, nodeController.unassignAgent);
+
+/**
+ * @swagger
+ * /{id}/nodes/{nodeId}/suggested-agents:
+ *   get:
+ *     summary: Get suggested agents for a task based on capability tags
+ *     tags: [Nodes]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: tags
+ *         schema:
+ *           type: string
+ *         description: Comma-separated capability tags to match
+ *     responses:
+ *       200:
+ *         description: List of suggested agents
+ */
+router.get('/:id/nodes/:nodeId/suggested-agents', authenticate, nodeController.getSuggestedAgents);
+
 module.exports = router;


### PR DESCRIPTION
## Task Assignment to Agents

Adds the ability to assign specific agents to task nodes based on their capabilities.

### Changes
- **Migration 00027**: Adds `assigned_agent_id`, `assigned_agent_at`, `assigned_agent_by` to plan_nodes
- **POST /plans/:id/nodes/:nodeId/assign-agent**: Assign an agent to a task
- **DELETE /plans/:id/nodes/:nodeId/assign-agent**: Unassign an agent
- **GET /plans/:id/nodes/:nodeId/suggested-agents**: Get capability-matched agent suggestions

Part of Phase 5: Multi-Agent Coordination