### PR TITLE
feat: Prompt-Based OpenClaw Integration - Backend

### DIFF
--- a/src/controllers/prompt.controller.js
+++ b/src/controllers/prompt.controller.js
@@ -1,0 +1,143 @@
+const { supabaseAdmin: supabase } = require('../config/supabase');
+const logger = require('../utils/logger');
+
+/**
+ * List prompt templates (user's own + plan-specific)
+ */
+const listPrompts = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const { plan_id, type } = req.query;
+
+    let query = supabase
+      .from('prompt_templates')
+      .select('*')
+      .or(`user_id.eq.${userId},is_default.eq.true`);
+
+    if (plan_id) {
+      query = query.or(`plan_id.eq.${plan_id},plan_id.is.null`);
+    }
+    if (type) {
+      query = query.eq('type', type);
+    }
+
+    const { data, error } = await query.order('created_at', { ascending: false });
+
+    if (error) {
+      await logger.error('Failed to list prompts', error);
+      return res.status(500).json({ error: 'Failed to list prompts' });
+    }
+
+    res.json(data || []);
+  } catch (error) {
+    await logger.error('Unexpected error in listPrompts', error);
+    next(error);
+  }
+};
+
+/**
+ * Create a prompt template
+ */
+const createPrompt = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const { name, template, description, type = 'custom', plan_id, variables = [] } = req.body;
+
+    if (!name || !template) {
+      return res.status(400).json({ error: 'name and template are required' });
+    }
+
+    const { data, error } = await supabase
+      .from('prompt_templates')
+      .insert({
+        user_id: userId,
+        plan_id: plan_id || null,
+        name,
+        template,
+        description: description || null,
+        type,
+        variables,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      await logger.error('Failed to create prompt', error);
+      return res.status(500).json({ error: 'Failed to create prompt' });
+    }
+
+    res.status(201).json(data);
+  } catch (error) {
+    await logger.error('Unexpected error in createPrompt', error);
+    next(error);
+  }
+};
+
+/**
+ * Update a prompt template
+ */
+const updatePrompt = async (req, res, next) => {
+  try {
+    const { promptId } = req.params;
+    const userId = req.user.id;
+    const { name, template, description, type, variables } = req.body;
+
+    const updateData = { updated_at: new Date().toISOString() };
+    if (name !== undefined) updateData.name = name;
+    if (template !== undefined) updateData.template = template;
+    if (description !== undefined) updateData.description = description;
+    if (type !== undefined) updateData.type = type;
+    if (variables !== undefined) updateData.variables = variables;
+
+    const { data, error } = await supabase
+      .from('prompt_templates')
+      .update(updateData)
+      .eq('id', promptId)
+      .eq('user_id', userId)
+      .select()
+      .single();
+
+    if (error) {
+      await logger.error('Failed to update prompt', error);
+      return res.status(500).json({ error: 'Failed to update prompt' });
+    }
+
+    res.json(data);
+  } catch (error) {
+    await logger.error('Unexpected error in updatePrompt', error);
+    next(error);
+  }
+};
+
+/**
+ * Delete a prompt template
+ */
+const deletePrompt = async (req, res, next) => {
+  try {
+    const { promptId } = req.params;
+    const userId = req.user.id;
+
+    const { error } = await supabase
+      .from('prompt_templates')
+      .delete()
+      .eq('id', promptId)
+      .eq('user_id', userId);
+
+    if (error) {
+      await logger.error('Failed to delete prompt', error);
+      return res.status(500).json({ error: 'Failed to delete prompt' });
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    await logger.error('Unexpected error in deletePrompt', error);
+    next(error);
+  }
+};
+
+module.exports = {
+  listPrompts,
+  createPrompt,
+  updatePrompt,
+  deletePrompt
+};

--- a/src/db/sql/00030_add_prompt_templates.sql
+++ b/src/db/sql/00030_add_prompt_templates.sql
@@ -1,0 +1,19 @@
+-- Migration: Add prompt templates for OpenClaw integration
+
+CREATE TABLE IF NOT EXISTS prompt_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id UUID REFERENCES plans(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  template TEXT NOT NULL,
+  description TEXT,
+  type TEXT NOT NULL DEFAULT 'plan' CHECK (type IN ('plan', 'task', 'review', 'summary', 'custom')),
+  is_default BOOLEAN DEFAULT false,
+  variables JSONB DEFAULT '[]'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_templates_plan ON prompt_templates(plan_id);
+CREATE INDEX IF NOT EXISTS idx_prompt_templates_user ON prompt_templates(user_id);
+CREATE INDEX IF NOT EXISTS idx_prompt_templates_type ON prompt_templates(type);

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const decisionRoutes = require('./routes/decision.routes');
 const dashboardRoutes = require('./routes/dashboard.routes');
 const handoffRoutes = require('./routes/handoff.routes');
 const chatRoutes = require('./routes/chat.routes');
+const promptRoutes = require('./routes/prompt.routes');
 // Removed: artifact controller (Phase 0 simplification)
 
 // Import WebSocket collaboration server
@@ -162,6 +163,7 @@ app.use('/dashboard', generalLimiter, dashboardRoutes);
 app.use('/plans', generalLimiter, handoffRoutes);
 app.use('/', generalLimiter, handoffRoutes);
 app.use('/plans', generalLimiter, chatRoutes);
+app.use('/prompts', generalLimiter, promptRoutes);
 
 // Removed: artifact download endpoint (Phase 0 simplification)
 const { authenticate } = require('./middleware/auth.middleware');

--- a/src/routes/prompt.routes.js
+++ b/src/routes/prompt.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const promptController = require('../controllers/prompt.controller');
+const { authenticate } = require('../middleware/auth.middleware');
+
+router.get('/', authenticate, promptController.listPrompts);
+router.post('/', authenticate, promptController.createPrompt);
+router.put('/:promptId', authenticate, promptController.updatePrompt);
+router.delete('/:promptId', authenticate, promptController.deletePrompt);
+
+module.exports = router;


### PR DESCRIPTION
Prompt template storage for configuring how OpenClaw interacts with plans.

- Migration 00030: prompt_templates table
- CRUD at /prompts (list, create, update, delete)
- Types: plan, task, review, summary, custom
- Variable support

Phase 7