### PR TITLE
docs: local-dev quickstart, smoke test, BUGS tracker

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,40 @@
+# BUGS
+
+Tracker for bugs and rough edges in agent-planner-api that aren't yet captured as plans or PRs. Add new entries to the top.
+
+## Open
+
+### `quick_log` MCP tool returns 400 where `add_log` succeeds with equivalent payload
+
+- **Reported:** 2026-04-25
+- **Reporter:** Claude Code session (during ap CLI BDI integration on agent-planner-mcp branch `feat/ap-cli-v1-core-loop`)
+- **Severity:** Low — workaround available
+
+**Repro:** Call `quick_log` via MCP with a valid `plan_id`, `task_id`, `log_type: "progress"`, and a `message` string. Server responds 400.
+
+```
+quick_log({
+  plan_id: "d1d3fba5-8d92-40e9-861f-f2ca4cea65be",
+  task_id: "638eb366-4ea1-4534-979e-6911c24bde03",
+  log_type: "progress",
+  message: "..."
+})
+→ Error: Request failed with status code 400
+```
+
+The same data sent through `add_log` (with `node_id` instead of `task_id` and `content` instead of `message`) succeeds and creates the log entry — see entry `6e1d95eb-eda5-4082-8252-0f0e71a134d8` on the dogfood task.
+
+**Suspected cause:** Field-name mismatch between the `quick_log` MCP wrapper and the underlying log endpoint, OR the `progress` log_type is not accepted by the route `quick_log` calls. Reproduced twice with different message lengths — content size is not the trigger.
+
+**Workaround:** Use `add_log` directly. Same effect, same `log_type` enum.
+
+**Where to look first:**
+- `agent-planner-mcp/src/tools.js` — the `quick_log` handler and how it shapes the request
+- `agent-planner/src/routes/*.routes.js` and `*.controller.v2.js` — the log endpoint validation (likely Zod schema in `validation/`)
+- Compare with how `add_log` formats its payload to the same backend
+
+---
+
+## Closed
+
+_(none yet)_

--- a/LOCAL_QUICKSTART.md
+++ b/LOCAL_QUICKSTART.md
@@ -1,0 +1,123 @@
+# Local Quickstart
+
+Get the AgentPlanner stack running locally and connect the `ap` CLI in under 5 minutes (after the first build).
+
+This is the **blessed local-dev path**. It runs the entire stack in Docker — postgres, falkordb, graphiti, api, frontend, mcp — with one command. If you want hot-reload backend development, use `docker-compose.yml` (with profiles) instead; this guide is for users who want a working stack to point a CLI or agent at.
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine + Compose v2)
+- An OpenAI API key (optional but recommended — required for the knowledge graph)
+
+## 1. Clone and configure
+
+```bash
+git clone https://github.com/TAgents/agent-planner.git
+cd agent-planner
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+```
+OPENAI_API_KEY=sk-...   # optional; without it the knowledge graph won't work, but plans/tasks will
+JWT_SECRET=...          # change from the default
+```
+
+## 2. Start the stack
+
+```bash
+docker compose -f docker-compose.local.yml up --build
+```
+
+First build: 5–10 minutes (npm install, frontend build, image pulls). Subsequent starts: under 30 seconds.
+
+When you see all services reporting healthy, the stack is up:
+
+| Service | URL | Purpose |
+|---|---|---|
+| API | http://localhost:3000 | REST API + Swagger at `/api-docs` |
+| Frontend | http://localhost:3001 | Web UI for registration + token management |
+| MCP | http://localhost:3100 | HTTP-mode MCP server (optional) |
+| Postgres | localhost:5433 | Database (mapped to host) |
+
+Graphiti and FalkorDB run internally and are not exposed to the host.
+
+## 3. Create an account and an API token
+
+1. Open http://localhost:3001
+2. Register a new account (any email/password — no verification in local mode)
+3. Go to **Settings → API Tokens**
+4. Click **Create token**, give it a name like `local-dev`, copy the token
+
+## 4. Install and connect the CLI
+
+```bash
+# install the CLI (publishes the same package as the MCP server)
+npm install -g agent-planner-mcp
+
+# log in against your local backend
+agent-planner-mcp login --api-url http://localhost:3000 --token <paste-token-here>
+```
+
+You should see:
+
+```
+Saved credentials to /Users/<you>/.agentplanner/config.json
+API URL: http://localhost:3000
+```
+
+If you have exactly one plan in the org, it auto-selects it as the default. Otherwise pass `--plan-id` later.
+
+> **Working from a clone of `agent-planner-mcp`?** Run `npm install && npm link` inside that repo instead of the global install. The same `agent-planner-mcp` binary will be on your PATH.
+
+## 5. Verify with the CLI
+
+```bash
+agent-planner-mcp tasks                    # queue view (will be empty until you create a plan)
+agent-planner-mcp next --plan-id <id>      # smart picker (resume → recommend → fallback)
+```
+
+Or use the bundled smoke-test script for an end-to-end check:
+
+```bash
+./scripts/smoke-localhost.sh <your-api-token>
+```
+
+The script verifies all health endpoints, creates a throwaway plan, and confirms the CLI can pull its context.
+
+## What's running
+
+```
++---------------------------------------------+
+|  Frontend (3001)  →  React UI               |
+|  API (3000)       →  Node/Express + JWT     |
+|  MCP (3100)       →  HTTP-mode MCP server   |
+|  Postgres (5433)  →  pg17 + pgvector        |
+|  Graphiti (-)     →  Knowledge graph (MCP)  |
+|  FalkorDB (-)     →  Graph DB for Graphiti  |
++---------------------------------------------+
+```
+
+## Common issues
+
+| Symptom | Fix |
+|---|---|
+| API healthcheck never goes green | Check `docker compose -f docker-compose.local.yml logs api` — usually a missing migration. Run `docker compose -f docker-compose.local.yml exec api npm run db:push`. |
+| `ap login` returns 401 | Token was for the wrong backend. Tokens from agentplanner.io don't work against localhost; create a new one in your local UI. |
+| Knowledge graph features fail silently | `OPENAI_API_KEY` not set in `.env`. All other features still work; learning writes return errors but don't block status updates. |
+| Port already in use | Edit the published ports in `docker-compose.local.yml` (3000, 3001, 3100, 5433) or stop the conflicting service. |
+
+## When to use what
+
+| Goal | Compose file |
+|---|---|
+| Run the stack locally to point a CLI/agent at | **`docker-compose.local.yml`** (this guide) |
+| Develop the backend with hot reload | `docker-compose.yml` (uses `--profile core --profile knowledge`) |
+| Production deployment to a VM | `docker-compose.prod.yml` |
+
+## Next steps
+
+- See `agent-planner-mcp/README.md` for the full CLI command reference (`tasks`, `next`, `context`, `start`, `blocked`, `done`, `--fresh`)
+- See `docs/GETTING_STARTED.md` for the human-side walkthrough (creating goals, plans, dependencies via the UI)
+- See `docs/VISION.md` for the agent-first philosophy

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The backend API for [AgentPlanner](https://agentplanner.io) — a collaborative 
 
 ### Quick Start with Docker Compose
 
+**For most users (recommended): see [LOCAL_QUICKSTART.md](LOCAL_QUICKSTART.md)** — the blessed 5-minute path that brings up the full stack (postgres + api + frontend + graphiti + mcp) in one command, ready for the `ap` CLI or any MCP client.
+
+For backend development with hot reload (separate use case), use the profile-based compose file:
+
 ```bash
 git clone https://github.com/TAgents/agent-planner.git
 cd agent-planner
@@ -41,7 +45,7 @@ cd agent-planner
 cp .env.example .env
 # Edit .env — set JWT_SECRET, OPENAI_API_KEY, and change default passwords
 
-# Start PostgreSQL + API
+# Start PostgreSQL + API only (no frontend, no graphiti)
 docker compose --profile core up -d
 
 # Run database migrations

--- a/scripts/smoke-localhost.sh
+++ b/scripts/smoke-localhost.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Smoke test for the local AgentPlanner stack.
+#
+# Verifies: API, Frontend, MCP healthchecks; creates a throwaway plan via the
+# REST API; confirms the ap CLI can read its context. Intended to be run after
+# `docker compose -f docker-compose.local.yml up`.
+#
+# Usage:
+#   ./scripts/smoke-localhost.sh <api-token>
+#
+# Pass an API token created in the local UI (Settings → API Tokens). The token
+# is sent as `Authorization: ApiKey <token>` to all REST calls.
+#
+# Exit code 0 = all checks passed. Non-zero = something is wrong; check the
+# preceding log lines for the failing step.
+
+set -uo pipefail
+
+API_URL="${API_URL:-http://localhost:3000}"
+UI_URL="${UI_URL:-http://localhost:3001}"
+MCP_URL="${MCP_URL:-http://localhost:3100}"
+TOKEN="${1:-}"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+info() { echo "       $1"; }
+
+if [ -z "$TOKEN" ]; then
+  echo "Usage: $0 <api-token>"
+  echo "  Create a token in the local UI at $UI_URL → Settings → API Tokens"
+  exit 2
+fi
+
+# Strip trailing slashes from URLs so url-joins are predictable.
+API_URL="${API_URL%/}"
+UI_URL="${UI_URL%/}"
+MCP_URL="${MCP_URL%/}"
+
+echo "Smoke test against:"
+echo "  API : $API_URL"
+echo "  UI  : $UI_URL"
+echo "  MCP : $MCP_URL"
+echo
+
+# ── 1. Healthchecks ──────────────────────────────────────────────────
+api_health=$(curl -sS -o /dev/null -w '%{http_code}' "$API_URL/health" || echo 000)
+if [ "$api_health" = "200" ]; then ok "API /health → 200"; else fail "API /health → $api_health (expected 200)"; fi
+
+ui_health=$(curl -sS -o /dev/null -w '%{http_code}' "$UI_URL/" || echo 000)
+if [ "$ui_health" = "200" ]; then ok "Frontend / → 200"; else fail "Frontend / → $ui_health (expected 200)"; fi
+
+# MCP exposes /.well-known/mcp.json or /health depending on transport. Try /health first.
+mcp_health=$(curl -sS -o /dev/null -w '%{http_code}' "$MCP_URL/health" || echo 000)
+if [ "$mcp_health" = "200" ]; then
+  ok "MCP /health → 200"
+else
+  mcp_disc=$(curl -sS -o /dev/null -w '%{http_code}' "$MCP_URL/.well-known/mcp.json" || echo 000)
+  if [ "$mcp_disc" = "200" ]; then
+    ok "MCP /.well-known/mcp.json → 200"
+  else
+    fail "MCP /health and /.well-known/mcp.json both unreachable (last codes: $mcp_health / $mcp_disc)"
+  fi
+fi
+
+# ── 2. Auth: token works against the API ─────────────────────────────
+auth_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H "Authorization: ApiKey $TOKEN" "$API_URL/plans" || echo 000)
+if [ "$auth_status" = "200" ]; then
+  ok "API /plans with token → 200"
+else
+  fail "API /plans with token → $auth_status (expected 200)"
+  info "Likely cause: token created in a different backend (e.g. agentplanner.io) or token expired."
+  echo
+  echo "Stopping early — fix auth before continuing."
+  exit 1
+fi
+
+# ── 3. Create a throwaway plan via REST ──────────────────────────────
+plan_response=$(curl -sS \
+  -H "Authorization: ApiKey $TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST "$API_URL/plans" \
+  -d '{"title":"smoke-test plan","description":"created by smoke-localhost.sh; safe to delete"}' || echo '')
+
+plan_id=$(echo "$plan_response" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -n1)
+
+if [ -n "$plan_id" ]; then
+  ok "Created throwaway plan: $plan_id"
+else
+  fail "Plan creation returned no id"
+  info "Raw response: $plan_response"
+fi
+
+# ── 4. Read the plan back to confirm persistence ─────────────────────
+if [ -n "$plan_id" ]; then
+  read_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H "Authorization: ApiKey $TOKEN" "$API_URL/plans/$plan_id" || echo 000)
+  if [ "$read_status" = "200" ]; then
+    ok "GET /plans/$plan_id → 200"
+  else
+    fail "GET /plans/$plan_id → $read_status"
+  fi
+fi
+
+# ── 5. CLI can pull context (only if ap binary is on PATH) ───────────
+if command -v agent-planner-mcp >/dev/null 2>&1; then
+  cli_dir=$(mktemp -d)
+  pushd "$cli_dir" >/dev/null
+
+  # The CLI reads the saved config from `ap login`; just check that ap context
+  # works against this throwaway plan with the token in env.
+  if [ -n "$plan_id" ]; then
+    ctx_output=$(USER_API_TOKEN="$TOKEN" API_URL="$API_URL" \
+      agent-planner-mcp context --plan-id "$plan_id" --dir "$cli_dir" 2>&1) || true
+    if [ -f "$cli_dir/.agentplanner/context.json" ]; then
+      ok "CLI wrote .agentplanner/context.json"
+    else
+      fail "CLI did not produce .agentplanner/context.json"
+      info "Note: the CLI uses ~/.agentplanner/config.json from \`ap login\`, not env vars."
+      info "Run: agent-planner-mcp login --api-url $API_URL --token \$TOKEN"
+      info "Output: $ctx_output"
+    fi
+  fi
+
+  popd >/dev/null
+  rm -rf "$cli_dir"
+else
+  info "agent-planner-mcp not on PATH — skipping CLI context check."
+  info "Install with: npm install -g agent-planner-mcp"
+fi
+
+# ── 6. Cleanup: delete the throwaway plan ────────────────────────────
+if [ -n "$plan_id" ]; then
+  del_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H "Authorization: ApiKey $TOKEN" \
+    -X DELETE "$API_URL/plans/$plan_id" || echo 000)
+  if [ "$del_status" = "200" ] || [ "$del_status" = "204" ]; then
+    ok "Deleted throwaway plan"
+  else
+    info "Could not delete throwaway plan $plan_id (status $del_status). Delete it via the UI when convenient."
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo
+echo "Result: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Bless `docker-compose.local.yml` as the local-dev path (full stack, single command, includes frontend for token creation).
- Add `LOCAL_QUICKSTART.md` — 5-minute path from clone to working CLI against localhost.
- Add `scripts/smoke-localhost.sh` — exercises healthchecks, token auth, plan CRUD, and CLI context.
- Add `BUGS.md` — internal bug tracker; first entry: `quick_log` returns 400 where `add_log` succeeds with equivalent payload.

## Commits

- `fdfc7d1` docs: add LOCAL_QUICKSTART.md as the blessed local-dev path
- `d90ffef` docs: add BUGS.md tracker; document quick_log 400 vs add_log

## Test plan

- [x] `bash -n scripts/smoke-localhost.sh` — syntax OK
- [ ] Fresh-machine run: clone → `docker compose -f docker-compose.local.yml up --build` → register → token → `ap login --api-url http://localhost:3000` → `./scripts/smoke-localhost.sh <token>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)