### PR TITLE
Persist per-dimension goal quality scores

### DIFF
--- a/migrations/0016_goal_evaluations_dimensions.sql
+++ b/migrations/0016_goal_evaluations_dimensions.sql
@@ -1,0 +1,14 @@
+-- Phase 16: Add dimensions column to goal_evaluations for per-dimension quality scores
+--
+-- Context: GET /goals/:id/quality computes a 5-dimension assessment (clarity,
+-- measurability, actionability, knowledge_grounding, commitment) on every call
+-- but never persists the per-dimension breakdown — only the rolled-up score
+-- can be stored today. Without dimensions, trending per-dimension over time is
+-- impossible. This adds a JSONB column to capture the full breakdown shape:
+--   { clarity: { score: 1.0, detail: "..." }, ... }
+--
+-- Backfill: existing rows have NULL dimensions. The endpoint at
+-- goals.routes.js:1224 will populate the column going forward when wired to
+-- call goalsDal.addEvaluation on each request.
+
+ALTER TABLE goal_evaluations ADD COLUMN IF NOT EXISTS dimensions JSONB;

--- a/src/db/schema/goals.mjs
+++ b/src/db/schema/goals.mjs
@@ -43,6 +43,7 @@ export const goalEvaluations = pgTable('goal_evaluations', {
   score: integer('score'),
   reasoning: text('reasoning'),
   suggestedActions: jsonb('suggested_actions'),
+  dimensions: jsonb('dimensions'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
 

--- a/src/routes/v2/goals.routes.js
+++ b/src/routes/v2/goals.routes.js
@@ -1293,12 +1293,29 @@ router.get('/:id/quality', authenticate, async (req, res) => {
     // Overall score
     const scores = Object.values(dimensions).map(d => d.score);
     const overall = scores.reduce((a, b) => a + b, 0) / scores.length;
+    const overallRounded = Math.round(overall * 100) / 100;
+    const assessedAt = new Date().toISOString();
+
+    // Persist to goal_evaluations for trending. Best-effort — failure here
+    // must not break the read endpoint.
+    try {
+      await goalsDal.addEvaluation(goal.id, {
+        evaluatedBy: 'goal_quality_endpoint',
+        score: Math.round(overall * 100),  // 0-100 integer for column type
+        reasoning: `Overall ${overallRounded}: clarity ${dimensions.clarity.score}, measurability ${dimensions.measurability.score}, actionability ${dimensions.actionability.score}, knowledge ${dimensions.knowledge_grounding.score}, commitment ${dimensions.commitment.score}`,
+        suggestedActions: suggestions,
+        dimensions,
+      });
+    } catch (persistErr) {
+      await logger.error('Goal quality persist failed:', persistErr);
+    }
 
     res.json({
       goal_id: goal.id,
-      score: Math.round(overall * 100) / 100,
+      score: overallRounded,
       dimensions,
       suggestions,
+      as_of: assessedAt,
     });
   } catch (err) {
     await logger.error('Goal quality error:', err);


### PR DESCRIPTION
## Summary
- Adds `dimensions` JSONB column to `goal_evaluations` (migration 0016) so the per-dimension breakdown returned by `GET /goals/:id/quality` is finally persisted on every call
- Adds `as_of` ISO 8601 timestamp on the response for cache-freshness signaling (consumed by Cowork live artifacts)
- Persistence is best-effort — failure to write does not break the read response
- Existing `GET /goals/:id/evaluations` endpoint surfaces the new `dimensions` automatically

## Why
The quality endpoint computed 5 dimensions (clarity, measurability, actionability, knowledge_grounding, commitment) on every call and threw them away. Trending per-dimension over time was therefore impossible. This is deliverable C of the Module Quality Telemetry plan referenced in the BDI redesign work.

## Deploy steps
- [ ] Merge this PR
- [ ] Apply migration: `npm run db:migrate` (prod) or `npm run db:push` (dev). The migration is additive and nullable on existing rows — no downtime expected.

## Test plan
- [ ] Migration applies cleanly on dev DB
- [ ] Quality endpoint returns response with `as_of` field populated
- [ ] Calling the quality endpoint multiple times produces multiple rows in `goal_evaluations` (time series)
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)